### PR TITLE
fix: add missing vim symbol for static image peripheral build

### DIFF
--- a/boards/shields/nice_oled/assets/vim.c
+++ b/boards/shields/nice_oled/assets/vim.c
@@ -299,3 +299,14 @@ const lv_img_dsc_t vim_68x69 = {
   .data_size = 620,
   .data = vim_68x69_map,
 };
+
+// Default vim image descriptor for static image peripheral
+const lv_img_dsc_t vim = {
+  .header.cf = LV_IMG_CF_INDEXED_1BIT,
+  .header.always_zero = 0,
+  .header.reserved = 0,
+  .header.w = 160,
+  .header.h = 68,
+  .data_size = 1368,
+  .data = vim_68x160_map,
+};


### PR DESCRIPTION
## Problem

  When building for the peripheral with
  `CONFIG_NICE_OLED_WIDGET_STATIC_IMAGE_PERIPHERAL_VIM=y`, the build fails
  with:

  undefined reference to `vim'

  ## Root Cause

  In `assets/vim.c`, only size-specific variants (`vim_32x100`, `vim_32x128`,
   `vim_68x69`, `vim_68x160`) are defined, but `widgets/animation.c`
  references the `vim` symbol via `LV_IMG_DECLARE(vim)` when the config
  option is enabled.

  ## Fix

  Added a default `vim` image descriptor that uses `vim_68x160_map` data.

  ## Testing

  Tested with:
  CONFIG_NICE_OLED_WIDGET_ANIMATION_PERIPHERAL=n
  CONFIG_NICE_OLED_WIDGET_STATIC_IMAGE_PERIPHERAL=y
  CONFIG_NICE_OLED_WIDGET_STATIC_IMAGE_PERIPHERAL_VIM=y

  Build now succeeds.