### PR TITLE
fix: skip full-canvas redraw on WPM ticks when no WPM visual is drawn on the canvas

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog file for Structures extra.
 https://github.com/mctechnology17/zmk-nice-oled/blob/main/CHANGELOG.txt
 
+# UNRELEASED
+=======================================
+# FIXES
+- [x] **Full-canvas WPM redraw skipped when no WPM visual is on the canvas** With WPM_NUMBER, WPM_SPEEDOMETER and WPM_GRAPH disabled (e.g. Luna or Bongo Cat only), the screen no longer redraws and rotates the whole canvas on every WPM tick; the animations update only their own area. Lower CPU load and better typing latency on the central side.
+
+
 # FEATURES v0.0.3 (Jan 09, 2026)
 =======================================
 # NEW FEATURES

--- a/boards/shields/nice_oled/widgets/screen.c
+++ b/boards/shields/nice_oled/widgets/screen.c
@@ -199,6 +199,19 @@ static void draw_battery_text(lv_obj_t *canvas, const struct status_state *state
 #include "wpm.h"
 #endif // IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
 
+// The full-canvas WPM listener is only needed when a WPM visual is drawn on
+// the canvas (number/speedometer/graph). Luna and Bongo Cat are standalone
+// lv_animimg widgets fed directly by the WPM event, so with only those
+// enabled the per-tick canvas redraw + rotation would be pure overhead.
+#if IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM) &&                                                     \
+    (IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM_NUMBER) ||                                             \
+     IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM_SPEEDOMETER) ||                                        \
+     IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM_GRAPH))
+#define NICE_OLED_WPM_ON_CANVAS 1
+#else
+#define NICE_OLED_WPM_ON_CANVAS 0
+#endif
+
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
 //  Declaración adelantada (Forward Declaration) para draw_canvas
@@ -872,9 +885,9 @@ static void draw_canvas(lv_obj_t *widget, lv_color_t cbuf[], const struct status
     draw_battery_text(canvas, state);
 #endif
 
-#if IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
+#if NICE_OLED_WPM_ON_CANVAS
     draw_wpm_status(canvas, state);
-#endif // IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
+#endif // NICE_OLED_WPM_ON_CANVAS
     draw_profile_status(canvas, state);
 #if IS_ENABLED(CONFIG_NICE_OLED_WIDGET_LAYER)
     draw_layer_status(canvas, state);
@@ -1081,7 +1094,7 @@ ZMK_SUBSCRIPTION(widget_output_status, zmk_ble_active_profile_changed);
  * WPM status
  **/
 
-#if IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
+#if NICE_OLED_WPM_ON_CANVAS
 static void set_wpm_status(struct zmk_widget_screen *widget, struct wpm_status_state state) {
     for (int i = 0; i < 9; i++) {
         widget->state.wpm[i] = widget->state.wpm[i + 1];
@@ -1103,7 +1116,7 @@ struct wpm_status_state wpm_status_get_state(const zmk_event_t *eh) {
 ZMK_DISPLAY_WIDGET_LISTENER(widget_wpm_status, struct wpm_status_state, wpm_status_update_cb,
                             wpm_status_get_state)
 ZMK_SUBSCRIPTION(widget_wpm_status, zmk_wpm_state_changed);
-#endif // IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
+#endif // NICE_OLED_WPM_ON_CANVAS
 
 /**
  * Initialization
@@ -1125,9 +1138,9 @@ int zmk_widget_screen_init(struct zmk_widget_screen *widget, lv_obj_t *parent) {
     widget_layer_status_init();
 #endif
     widget_output_status_init();
-#if IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
+#if NICE_OLED_WPM_ON_CANVAS
     widget_wpm_status_init();
-#endif // IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
+#endif // NICE_OLED_WPM_ON_CANVAS
 
 #if IS_ENABLED(CONFIG_NICE_OLED_WIDGET_WPM)
 

--- a/docs/OPTIMIZE.md
+++ b/docs/OPTIMIZE.md
@@ -129,6 +129,22 @@ Options:
 
 ## Animation Optimization
 
+### Luna / Bongo Cat without the WPM counter
+
+Luna and Bongo Cat need the WPM *subsystem* (it drives their idle/walk/run
+states) but not the on-canvas WPM *visuals*. When `WPM_NUMBER`,
+`WPM_SPEEDOMETER`, and `WPM_GRAPH` are all disabled, the module skips the
+full-canvas redraw that used to run on every WPM tick — only the small
+animation area is updated. So the cheapest Luna setup is:
+
+```ini
+CONFIG_NICE_OLED_WIDGET_WPM=y
+CONFIG_NICE_OLED_WIDGET_WPM_LUNA=y
+CONFIG_NICE_OLED_WIDGET_WPM_NUMBER=n
+CONFIG_NICE_OLED_WIDGET_WPM_SPEEDOMETER=n
+CONFIG_NICE_OLED_WIDGET_WPM_GRAPH=n
+```
+
 ### Animation Duration
 
 Longer durations = less CPU usage, smoother appearance.


### PR DESCRIPTION
## Problem

When only Luna or Bongo Cat is enabled (`WPM_NUMBER`, `WPM_SPEEDOMETER` and `WPM_GRAPH` all `n` — the shipped defaults), `draw_wpm_status()` draws nothing, but `screen.c` still subscribes the whole status screen to `zmk_wpm_state_changed`. Result: roughly once per second while typing, the entire canvas is redrawn and software-rotated (`rotate_canvas`) for no visual change. On a split central that CPU time competes with key scanning and BLE, and it shows up as typing lag.

## Change

The full-canvas WPM listener, its init, and the `draw_wpm_status()` call are now compiled only when at least one canvas WPM visual (`WPM_NUMBER` / `WPM_SPEEDOMETER` / `WPM_GRAPH`) is enabled. Luna and Bongo Cat are unaffected: they are standalone `lv_animimg` widgets fed directly by the WPM event and update only their own area.

No behavior change for anyone who has a WPM visual enabled. `docs/OPTIMIZE.md` gains a section describing the "Luna without the counter" setup, and `CHANGELOG.txt` is updated.

## Verification

Built against ZMK v0.3.0 (`nice_nano_v2`, `corne_left`/`corne_right nice_oled`):
- default config (Bongo Cat, no WPM visuals) — listener compiled out, builds clean
- Luna-only config — builds clean
- config with `WPM_NUMBER=y` — listener still compiled in


https://github.com/user-attachments/assets/1534d273-feec-49ea-9ab9-dfa022824cfd

