### PR TITLE
fix: honor CONFIG_NICE_OLED_WIDGET_WPM_LUNA_ANIMATION_MS and WPM_BONGO_CAT_ANIMATION_MS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog file for Structures extra.
 https://github.com/mctechnology17/zmk-nice-oled/blob/main/CHANGELOG.txt
 
+# UNRELEASED
+=======================================
+# FIXES
+- [x] **CONFIG_NICE_OLED_WIDGET_WPM_LUNA_ANIMATION_MS and CONFIG_NICE_OLED_WIDGET_WPM_BONGO_CAT_ANIMATION_MS are now honored** Both were documented in docs/OPTIMIZE.md but the widgets used hardcoded cycle times (200ms walk/run). Luna derives all states from the option (idle at 3x the base), Bongo Cat uses it for the fast state. Effective default changes from 200ms to the Kconfig default of 300ms.
+
+
 # FEATURES v0.0.3 (Jan 09, 2026)
 =======================================
 # NEW FEATURES

--- a/boards/shields/nice_oled/widgets/bongo_cat.c
+++ b/boards/shields/nice_oled/widgets/bongo_cat.c
@@ -78,7 +78,9 @@ const lv_img_dsc_t *mid_imgs[] = {
     &bongo_cat_tap2_03,
 };
 
-#define ANIMATION_SPEED_FAST 200
+// The fast state dominates CPU usage while typing, so it is the one exposed
+// through Kconfig (see docs/OPTIMIZE.md).
+#define ANIMATION_SPEED_FAST CONFIG_NICE_OLED_WIDGET_WPM_BONGO_CAT_ANIMATION_MS
 const lv_img_dsc_t *fast_imgs[] = {
     &bongo_cat_double_tap2_02,
     &bongo_cat_double_tap1_03,

--- a/boards/shields/nice_oled/widgets/luna.c
+++ b/boards/shields/nice_oled/widgets/luna.c
@@ -30,28 +30,34 @@ LV_IMG_DECLARE(dog_run2_90);
 LV_IMG_DECLARE(dog_sneak1_90);
 LV_IMG_DECLARE(dog_sneak2_90);
 
-// #define ANIMATION_SPEED_IDLE 10000
-#define ANIMATION_SPEED_IDLE 960
+// Base cycle time comes from Kconfig so CPU usage is tunable (see
+// docs/OPTIMIZE.md). Idle runs at 3x the base so the sitting dog stays calm.
+// The Kconfig symbol only exists on central; peripheral builds with
+// NICE_OLED_WIDGET_ANIMATION_PERIPHERAL_WPM fall back to the same default.
+#ifdef CONFIG_NICE_OLED_WIDGET_WPM_LUNA_ANIMATION_MS
+#define ANIMATION_SPEED_BASE CONFIG_NICE_OLED_WIDGET_WPM_LUNA_ANIMATION_MS
+#else
+#define ANIMATION_SPEED_BASE 300
+#endif
+#define ANIMATION_SPEED_IDLE (ANIMATION_SPEED_BASE * 3)
 const lv_img_dsc_t *idle_imgs[] = {
     &dog_sit1_90,
     &dog_sit2_90,
 };
 
-// #define ANIMATION_SPEED_SLOW 2000
-#define ANIMATION_SPEED_SLOW 200
+#define ANIMATION_SPEED_SLOW ANIMATION_SPEED_BASE
 const lv_img_dsc_t *slow_imgs[] = {
     &dog_walk1_90,
     &dog_walk2_90,
 };
 
-// #define ANIMATION_SPEED_MID 500
-#define ANIMATION_SPEED_MID 200
+#define ANIMATION_SPEED_MID ANIMATION_SPEED_BASE
 const lv_img_dsc_t *mid_imgs[] = {
     &dog_walk1_90,
     &dog_walk2_90,
 };
 
-#define ANIMATION_SPEED_FAST 200
+#define ANIMATION_SPEED_FAST ANIMATION_SPEED_BASE
 const lv_img_dsc_t *fast_imgs[] = {
     &dog_run1_90,
     &dog_run2_90,


### PR DESCRIPTION
## Problem

`CONFIG_NICE_OLED_WIDGET_WPM_LUNA_ANIMATION_MS` and `CONFIG_NICE_OLED_WIDGET_WPM_BONGO_CAT_ANIMATION_MS` exist in Kconfig and are documented in `docs/OPTIMIZE.md` as the CPU tuning knob for these animations, but neither widget reads them: `luna.c` and `bongo_cat.c` use hardcoded cycle times (200 ms for walk/run — ~10 redraws/s while typing fast).

## Change

- `luna.c`: all states derive from the Kconfig value; idle runs at 3x the base so the sitting dog stays calm (default 300 → idle 900 ms, close to the previous 960 ms).
- `bongo_cat.c`: the fast state (the one that dominates CPU while typing) uses the Kconfig value; idle/slow/mid keep their existing slow timings.

**Note — effective default changes** from the hardcoded 200 ms to the Kconfig default of 300 ms (slightly slower, cheaper). Users can restore the old feel with `..._ANIMATION_MS=200`.

`luna.c` falls back to 300 ms when the symbol is undefined, since the option only exists on the central but the file is also compiled for `NICE_OLED_WIDGET_ANIMATION_PERIPHERAL_WPM`. (Unrelated: that peripheral config currently fails to link on ZMK v0.3.0 because `ZMK_WPM` needs keycode events that don't exist on the peripheral — pre-existing, reproduced with unmodified `main`.)

## Verification

Built against ZMK v0.3.0 (`nice_nano_v2`): default config (Bongo Cat) and a Luna config with `..._LUNA_ANIMATION_MS=400`; the value lands in `.config` and builds are clean.
