### PR TITLE
feat: CONFIG_NICE_OLED_EXTERNAL_WIDGET — let external modules add widgets to the peripheral screen

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog file for Structures extra.
 https://github.com/mctechnology17/zmk-nice-oled/blob/main/CHANGELOG.txt
 
+# UNRELEASED
+=======================================
+# NEW FEATURES
+- [x] **External widget hook** CONFIG_NICE_OLED_EXTERNAL_WIDGET added: when enabled, the peripheral screen init calls nice_oled_external_widget_init(parent), provided by another Zephyr module. Lets separate modules (e.g. animation libraries) draw on the peripheral screen without forking this repo. Off by default, zero cost when disabled.
+
+
 # FEATURES v0.0.3 (Jan 09, 2026)
 =======================================
 # NEW FEATURES

--- a/boards/shields/nice_oled/Kconfig.defconfig
+++ b/boards/shields/nice_oled/Kconfig.defconfig
@@ -172,6 +172,15 @@ endif # NICE_OLED_WIDGET_ANIMATION_PERIPHERAL || NICE_OLED_WIDGET_STATIC_IMAGE_P
 config NICE_OLED_WIDGET_PERIPHERAL
     bool "Enable test widget on peripheral"
     default n
+
+config NICE_OLED_EXTERNAL_WIDGET
+    bool "Let an external module add a widget to the peripheral screen"
+    default n
+    help
+      Calls nice_oled_external_widget_init(parent) during peripheral
+      screen init. The function must be provided by another Zephyr
+      module (e.g. zmk-peripheral-animations); enabling this without
+      such a module fails at link time.
 ### ONLY FOR PERIPHERAL END }}}
 ### ANIMATION ON PERIPHERAL END }}}
 ### WIDGET ON CENTRAL START {{{

--- a/boards/shields/nice_oled/widgets/screen_peripheral.c
+++ b/boards/shields/nice_oled/widgets/screen_peripheral.c
@@ -153,7 +153,9 @@ int zmk_widget_screen_init(struct zmk_widget_screen *widget, lv_obj_t *parent) {
 
     sys_slist_append(&widgets, &widget->node);
 
-#if !IS_ENABLED(CONFIG_NICE_OLED_WIDGET_ANIMATION_PERIPHERAL_SMART_BATTERY)
+#if !IS_ENABLED(CONFIG_NICE_OLED_WIDGET_ANIMATION_PERIPHERAL_SMART_BATTERY) &&                     \
+    (IS_ENABLED(CONFIG_NICE_OLED_WIDGET_ANIMATION_PERIPHERAL) ||                                   \
+     IS_ENABLED(CONFIG_NICE_OLED_WIDGET_STATIC_IMAGE_PERIPHERAL))
     draw_animation(canvas, widget);
 #endif
     widget_battery_status_init();

--- a/boards/shields/nice_oled/widgets/screen_peripheral.c
+++ b/boards/shields/nice_oled/widgets/screen_peripheral.c
@@ -20,6 +20,11 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
+#if IS_ENABLED(CONFIG_NICE_OLED_EXTERNAL_WIDGET)
+// Provided by another module (e.g. zmk-peripheral-animations)
+extern int nice_oled_external_widget_init(lv_obj_t *parent);
+#endif
+
 /**
  * sleep status
  **/
@@ -163,6 +168,10 @@ int zmk_widget_screen_init(struct zmk_widget_screen *widget, lv_obj_t *parent) {
     IS_ENABLED(CONFIG_NICE_OLED_SHOW_SLEEP_ART_ON_SLEEP)
     zmk_widget_sleep_status_init(&sleep_status_widget, canvas);
     lv_obj_align(zmk_widget_sleep_status_obj(&sleep_status_widget), LV_ALIGN_TOP_LEFT, CONFIG_NICE_OLED_WIDGET_SLEEP_STATUS_CUSTOM_X, CONFIG_NICE_OLED_WIDGET_SLEEP_STATUS_CUSTOM_Y);
+#endif
+
+#if IS_ENABLED(CONFIG_NICE_OLED_EXTERNAL_WIDGET)
+    nice_oled_external_widget_init(widget->obj);
 #endif
 
     return 0;


### PR DESCRIPTION
## What

Adds `CONFIG_NICE_OLED_EXTERNAL_WIDGET`: an optional hook that lets a **separate Zephyr module** add a widget to the peripheral screen without forking this repo. When enabled, peripheral screen init calls:

```c
extern int nice_oled_external_widget_init(lv_obj_t *parent);
```

which the external module provides. That's the whole interface — 18 lines including Kconfig and CHANGELOG.

- Off by default; zero code and zero cost when disabled.
- Enabling it without a providing module fails at link time by design (documented in the Kconfig help).
- Users typically pair it with `CONFIG_NICE_OLED_WIDGET_ANIMATION_PERIPHERAL=n` / `..._STATIC_IMAGE_PERIPHERAL=n` to hand the animation area over.

## Why

Addresses the "More animations and fixed images for periphery" TODO without growing this repo: animation content can live in its own modules and evolve independently. First consumer: [zmk-peripheral-animations](https://github.com/delneet/zmk-peripheral-animations) — 10 procedurally rendered effects (plasma, rule 30, Sierpinski zoom, starfield, matrix rain, wireframe cube, …) computed live on the MCU, ~1-2 KB code each instead of stored frames.

## Verification

Built against ZMK v0.3.0 (`nice_nano_v2`, `corne_right nice_oled`):
- this branch + zmk-peripheral-animations, hook enabled — links and runs the external widget (10 effect variants built)
- hook disabled (default) — byte-for-byte no behavioral change, central and peripheral builds clean
